### PR TITLE
Scaffold app frontend and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,82 @@
-# Heartbeat-Ravers
+# Heartbeat Ravers
+
+## Überblick
+
+Dieses Repository enthält die Grundstruktur für die Heartbeat-Ravers-Anwendung. Das Projekt ist in
+zwei Hauptteile unterteilt:
+
+- **Backend** – Ein schnelles FastAPI-Projekt, das Beispiel-Endpunkte und Pydantic-Modelle für
+  Benutzer und Events bereitstellt.
+- **Frontend** – Ein React-/Vite-Setup mit einer Startseite, Login-/Registrierungsformularen und
+  einem Profil-Platzhalter.
+
+## Tech-Stack
+
+| Bereich   | Technologie            | Beschreibung                                                     |
+|-----------|------------------------|------------------------------------------------------------------|
+| Backend   | [FastAPI](https://fastapi.tiangolo.com/) | Modernes Python-Webframework mit Typsicherheit und OpenAPI-Unterstützung. |
+| Backend   | [Uvicorn](https://www.uvicorn.org/)       | ASGI-Server zum lokalen Starten des FastAPI-Backends.             |
+| Frontend  | [React](https://react.dev/)               | UI-Bibliothek zur Erstellung der Benutzeroberfläche.              |
+| Frontend  | [Vite](https://vitejs.dev/)               | Entwicklungs- und Build-Tooling für das React-Frontend.          |
+
+## Projektstruktur
+
+```
+app/
+├── backend/
+│   ├── app/
+│   │   ├── __init__.py
+│   │   ├── main.py
+│   │   └── models.py
+│   └── requirements.txt
+└── frontend/
+    ├── index.html
+    ├── package.json
+    ├── vite.config.js
+    └── src/
+        ├── App.jsx
+        ├── main.jsx
+        ├── pages/
+        │   ├── HomePage.jsx
+        │   ├── LoginPage.jsx
+        │   ├── ProfilePage.jsx
+        │   └── RegisterPage.jsx
+        └── styles.css
+```
+
+## Lokale Entwicklung
+
+### Voraussetzungen
+
+- **Backend:** Python 3.11 (oder höher) empfohlen
+- **Frontend:** Node.js 18 (oder höher) sowie npm oder pnpm
+
+### Backend starten
+
+```bash
+cd app/backend
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload --port 8000
+```
+
+Der Service ist danach unter <http://localhost:8000> erreichbar. Die API-Dokumentation befindet sich
+unter <http://localhost:8000/docs>.
+
+### Frontend starten
+
+```bash
+cd app/frontend
+npm install
+npm run dev -- --host
+```
+
+Die Entwicklungsoberfläche ist im Browser unter <http://localhost:5173> verfügbar. Die Beispielseiten
+verwenden Platzhalterlogik, um später an das Backend angebunden zu werden.
+
+## Nächste Schritte
+
+- Persistente Datenbank und echte Authentifizierung ergänzen.
+- API-Aufrufe vom Frontend an das Backend einbinden.
+- UI mit Branding, Dark Mode und Event-Features erweitern.

--- a/app/backend/app/__init__.py
+++ b/app/backend/app/__init__.py
@@ -1,0 +1,5 @@
+"""Heartbeat Ravers backend package."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/app/backend/app/main.py
+++ b/app/backend/app/main.py
@@ -1,0 +1,63 @@
+"""FastAPI application entrypoint for Heartbeat Ravers."""
+
+from datetime import datetime, timedelta
+from typing import List
+
+from fastapi import FastAPI, HTTPException
+
+from .models import Event, User, UserCreate
+
+app = FastAPI(title="Heartbeat Ravers API", version="0.1.0")
+
+# In-memory demo storage.
+_USERS: List[User] = [
+    User(id=1, email="raver@example.com", display_name="Demo Raver", created_at=datetime.utcnow())
+]
+_EVENTS: List[Event] = [
+    Event(
+        id=1,
+        name="Opening Night",
+        location="Main Stage",
+        start_time=datetime.utcnow() + timedelta(days=7),
+        end_time=None,
+        attendees=_USERS.copy(),
+    )
+]
+
+
+@app.get("/", summary="Service health check")
+def read_root() -> dict[str, str]:
+    """Return a simple heartbeat so clients know the service is online."""
+
+    return {"message": "Heartbeat Ravers API is running"}
+
+
+@app.get("/users", response_model=List[User], summary="List users")
+def list_users() -> List[User]:
+    """List demo users."""
+
+    return _USERS
+
+
+@app.post("/users", response_model=User, status_code=201, summary="Create a user")
+def create_user(payload: UserCreate) -> User:
+    """Create a user in the demo in-memory store."""
+
+    if any(user.email == payload.email for user in _USERS):
+        raise HTTPException(status_code=400, detail="Email already registered")
+
+    user = User(
+        id=len(_USERS) + 1,
+        email=payload.email,
+        display_name=payload.display_name,
+        created_at=datetime.utcnow(),
+    )
+    _USERS.append(user)
+    return user
+
+
+@app.get("/events", response_model=List[Event], summary="List events")
+def list_events() -> List[Event]:
+    """Return demo events."""
+
+    return _EVENTS

--- a/app/backend/app/models.py
+++ b/app/backend/app/models.py
@@ -1,0 +1,37 @@
+"""Data models for the Heartbeat Ravers backend."""
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class UserBase(BaseModel):
+    """Shared attributes for user representations."""
+
+    email: EmailStr
+    display_name: str
+
+
+class UserCreate(UserBase):
+    """Payload for creating a new user."""
+
+    password: str
+
+
+class User(UserBase):
+    """Public-facing user model."""
+
+    id: int
+    created_at: datetime
+
+
+class Event(BaseModel):
+    """Simple event model used by the sample endpoints."""
+
+    id: int
+    name: str
+    location: str
+    start_time: datetime
+    end_time: Optional[datetime]
+    attendees: List[User] = Field(default_factory=list)

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.1
+pydantic[email]==2.7.1

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Heartbeat Ravers</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "heartbeat-ravers-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.2.0"
+  }
+}

--- a/app/frontend/src/App.jsx
+++ b/app/frontend/src/App.jsx
@@ -1,0 +1,35 @@
+import { NavLink, Route, Routes } from "react-router-dom";
+
+import HomePage from "./pages/HomePage.jsx";
+import LoginPage from "./pages/LoginPage.jsx";
+import RegisterPage from "./pages/RegisterPage.jsx";
+import ProfilePage from "./pages/ProfilePage.jsx";
+
+const App = () => {
+  return (
+    <div className="app">
+      <header className="app__header">
+        <h1>Heartbeat Ravers</h1>
+        <nav className="app__nav">
+          <NavLink to="/" end>
+            Home
+          </NavLink>
+          <NavLink to="/login">Login</NavLink>
+          <NavLink to="/register">Register</NavLink>
+          <NavLink to="/profile">Profile</NavLink>
+        </nav>
+      </header>
+      <main className="app__main">
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+          <Route path="/profile" element={<ProfilePage />} />
+        </Routes>
+      </main>
+      <footer className="app__footer">&copy; {new Date().getFullYear()} Heartbeat Ravers</footer>
+    </div>
+  );
+};
+
+export default App;

--- a/app/frontend/src/main.jsx
+++ b/app/frontend/src/main.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+
+import App from "./App.jsx";
+import "./styles.css";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/app/frontend/src/pages/HomePage.jsx
+++ b/app/frontend/src/pages/HomePage.jsx
@@ -1,0 +1,17 @@
+const HomePage = () => {
+  return (
+    <section className="page">
+      <h2>Welcome to Heartbeat Ravers</h2>
+      <p>
+        Discover upcoming events, connect with fellow ravers, and keep your finger on the
+        pulse of the electronic music scene.
+      </p>
+      <p>
+        This placeholder frontend is ready for integration with the FastAPI backend. Use it as
+        the starting point for a richer, data-driven experience.
+      </p>
+    </section>
+  );
+};
+
+export default HomePage;

--- a/app/frontend/src/pages/LoginPage.jsx
+++ b/app/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+
+const LoginPage = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    alert(`Login for ${email} is not wired up yet. Connect to the API to continue.`);
+  };
+
+  return (
+    <section className="page">
+      <h2>Login</h2>
+      <form className="form" onSubmit={handleSubmit}>
+        <label>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+          />
+        </label>
+        <button type="submit">Sign in</button>
+      </form>
+    </section>
+  );
+};
+
+export default LoginPage;

--- a/app/frontend/src/pages/ProfilePage.jsx
+++ b/app/frontend/src/pages/ProfilePage.jsx
@@ -1,0 +1,21 @@
+const ProfilePage = () => {
+  return (
+    <section className="page">
+      <h2>Your profile</h2>
+      <p>
+        This is a placeholder for the future profile experience. Once authentication is wired
+        to the backend, this view can display saved events, personal preferences, and more.
+      </p>
+      <div className="placeholder-card">
+        <p>Profile summary</p>
+        <ul>
+          <li>Display name</li>
+          <li>Favorite genres</li>
+          <li>Upcoming events</li>
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default ProfilePage;

--- a/app/frontend/src/pages/RegisterPage.jsx
+++ b/app/frontend/src/pages/RegisterPage.jsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+
+const RegisterPage = () => {
+  const [formData, setFormData] = useState({
+    email: "",
+    displayName: "",
+    password: "",
+  });
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((current) => ({ ...current, [name]: value }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    alert(`Registration for ${formData.displayName} is not connected yet.`);
+  };
+
+  return (
+    <section className="page">
+      <h2>Create an account</h2>
+      <form className="form" onSubmit={handleSubmit}>
+        <label>
+          Display name
+          <input
+            name="displayName"
+            value={formData.displayName}
+            onChange={handleChange}
+            required
+          />
+        </label>
+        <label>
+          Email
+          <input
+            type="email"
+            name="email"
+            value={formData.email}
+            onChange={handleChange}
+            required
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            name="password"
+            value={formData.password}
+            onChange={handleChange}
+            required
+          />
+        </label>
+        <button type="submit">Join the community</button>
+      </form>
+    </section>
+  );
+};
+
+export default RegisterPage;

--- a/app/frontend/src/styles.css
+++ b/app/frontend/src/styles.css
@@ -1,0 +1,109 @@
+:root {
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.5;
+  color: #1f2933;
+  background-color: #f8fafc;
+}
+
+a {
+  font-weight: 500;
+  color: #2563eb;
+  text-decoration: none;
+}
+
+a.active {
+  text-decoration: underline;
+}
+
+body {
+  margin: 0;
+}
+
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app__header {
+  background: linear-gradient(135deg, #1d4ed8, #9333ea);
+  color: white;
+  padding: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.app__nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.app__main {
+  flex: 1;
+  padding: 2rem;
+  max-width: 960px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.app__footer {
+  text-align: center;
+  padding: 1rem;
+  background-color: #e2e8f0;
+  color: #475569;
+}
+
+.page {
+  background-color: white;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+}
+
+.page h2 {
+  margin-top: 0;
+}
+
+.form {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.form label {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.form input {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+}
+
+.form button {
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #1d4ed8, #9333ea);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.placeholder-card {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background-color: #f1f5f9;
+  border: 1px dashed #94a3b8;
+}
+
+.placeholder-card ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+}

--- a/app/frontend/vite.config.js
+++ b/app/frontend/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: "0.0.0.0",
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a FastAPI backend with sample routes and Pydantic models for users and events
- add a Vite-powered React frontend with home, auth, and profile placeholder pages
- document the new application layout, tech stack, and local setup steps in the README

## Testing
- python -m compileall app/backend/app

------
https://chatgpt.com/codex/tasks/task_e_68cc9a9ae50883299b70744ec5355b33